### PR TITLE
Clicking foundation pile, causes crash.

### DIFF
--- a/GameManager.cpp
+++ b/GameManager.cpp
@@ -721,6 +721,13 @@ std::vector<Card*> GameManager::getCardsAtMousePosition(const sf::Vector2i& pMou
 	// check the foundation piles
 	for (uint32_t i = 0; i < mFoundations.size(); ++i)
 	{
+		// Sorry if this breaks more than it fixes. -Alex
+		if (mFoundations[i].isEmpty())
+		{
+			std::cout << "Foundation [" << i << "] empty, ignoring." << std::endl;
+			continue;
+		}
+
 		if (mFoundations[i].isMouseOverTopCard(mousePosition))
 		{
 			card = mFoundations[i].peek();

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,6 @@
+# Solitaire SFML \[FORK\]
+
+This is a fork of l-paz91's Solitaire SFML.
+It can be found here.
+
+also this was forked to make a pull request :\)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,0 @@
-# Solitaire SFML \[FORK\]
-
-This is a fork of l-paz91's Solitaire SFML.
-It can be found here.
-
-also this was forked to make a pull request :\)


### PR DESCRIPTION
Clicking on an empty foundation pile, caused an null exception.
Ends up crashing the application.